### PR TITLE
音声再生に関する不具合を修正

### DIFF
--- a/TrainCrewMotorSound/MainForm.cs
+++ b/TrainCrewMotorSound/MainForm.cs
@@ -509,8 +509,8 @@ namespace TrainCrewMotorSound
                         isRunSection = true;
                         continue;
                     }
-                    // 空白行または別セクションならスキップし、セクション終了を示す
-                    else if (string.IsNullOrWhiteSpace(line) || (line.StartsWith("[") && line.EndsWith("]")))
+                    // 別セクションならスキップし、セクション終了を示す
+                    else if ((line.StartsWith("[") && line.EndsWith("]")))
                     {
                         isMotorSection = false;
                         isRunSection = false;

--- a/TrainCrewMotorSound/Sound.cs
+++ b/TrainCrewMotorSound/Sound.cs
@@ -281,11 +281,13 @@ namespace TrainCrewMotorSound
             if (type.ToUpper() == "MOTOR")
             {
                 if (index < 0 || index >= motorSoundSource.Count || motorSoundSource[index] == null) return;
+                if (volume < 0) volume = 0;
                 motorSoundSource[index].SetVolume(fMotorMasterVolume * volume);
             }
             else if (type.ToUpper() == "RUN")
             {
                 if (index < 0 || index >= runSoundSource.Count || runSoundSource[index] == null) return;
+                if (volume < 0) volume = 0;
                 runSoundSource[index].SetVolume(fRunMasterVolume * volume);
             }
         }


### PR DESCRIPTION
・音量がマイナス値を取る際、音声が絶対値で再生されることにより爆音となる事象を修正。
・Sound.txtにおいて、セクション区切りが空行で切られており、空行スペースあけされている車両ではインデックス不足となる問題を修正。